### PR TITLE
make debug message easier to read

### DIFF
--- a/fmREST.php
+++ b/fmREST.php
@@ -343,8 +343,10 @@ class fmREST {
 	function __destruct() {
 		global $debug;
 		if ($debug) {
-			echo "\nDEBUGGING ON: \n";
+			echo "<strong>DEBUGGING ON: </strong><br>";
+			echo "<pre>";
 			print_r ($this->debug_array);
+			echo "</pre>";
 		}	
 	}
 


### PR DESCRIPTION
hi there
If possible, my patch may help user read debug message easier.

I'm just learning your fmREST class. It's easier to learn than other PHP implementations.
I'm not a PHP fan but seems like it make me not to learn the whole mvc framework. (At least for now)

Thank you